### PR TITLE
Change default initial state of watch

### DIFF
--- a/stopWatch.html
+++ b/stopWatch.html
@@ -76,7 +76,7 @@
 			}
 	    	
 	    	//creates a watch object
-	    	function Watch(status = 1, title, startTime=Date.now(), curTime=Date.now(), notes=[]) {
+	    	function Watch(status = 0, title, startTime=Date.now(), curTime=Date.now(), notes=[]) {
 	    		if(title == null)
 	    			title = document.getElementById('title').value;
 	    		this.id = idCounter;


### PR DESCRIPTION
This will force the user to click "play" when a new stopwatch is created rather than it being played immediately.